### PR TITLE
Fixed typos/errors in the various places

### DIFF
--- a/Drawable.md
+++ b/Drawable.md
@@ -2,20 +2,20 @@
 
 H2D classes that can display something on screen usually extend the [`h2d.Drawable`](https://github.com/ncannasse/heaps/blob/master/h2d/Drawable.hx) class.
 
-Each Drawable (including [`h2d.Bitmap`](https://github.com/ncannasse/heaps/blob/master/h2d/Bitmap.hx) has then several properties that can be manipulated:
+Each Drawable (including [`h2d.Bitmap`](https://github.com/ncannasse/heaps/blob/master/h2d/Bitmap.hx)) has several properties that can be manipulated:
 
 * `alpha` : this will change the amount of transparency your drawable is displayed with. For instance a value of 0.5 will display a Tile with 50% opacity.
-* `color` : color is the color multiplier of the drawable. You can access its individual channels with (r,g,b,a) components. It is initialy set to white (all components are set to 1.). Setting for instance the (r,g,b) components to 0.5 will make the tile appear more dark.
-* `blendMode` : the blend mode tells how the drawable gets composited with the background color when its drawn on the screen. The background color refers to the screen content at the time the sprite is being drawn. This can be another sprite content if it was drawn before at the same position. The following blend mode values are available :  
+* `color` : color is the color multiplier of the drawable. You can access its individual channels with (r,g,b,a) components. It is initialy set to white (all components are set to 1.). Setting for instance the (r,g,b) components to 0.5 will make the tile appear darker.
+* `blendMode` : the blend mode tells how the drawable gets composited with the background color when it is drawn on the screen. The background color refers to the screen content at the time the sprite is being drawn. This can be another sprite content if it was drawn before at the same position. The following blend mode values are available :  
 	
     * `Alpha` (default) : the drawable blends itself with the background using its alpha value. An opaque pixel will erase the background, a fully transparent one will be ignored.
-    * `None` : this disable the blending with the background. Alpha channel is ignored and the color is written as-it. This offers the best display performances for large backgrounds that have nothing showing being them
+    * `None` : this disable the blending with the background. Alpha channel is ignored and the color is written as-is. This offers the best display performances for large backgrounds that have nothing displayed behind them
     * `Add` : the drawable color will be added to the background, useful for creating explosions effects or particles for instance.
     * `SoftAdd` : similar to Add but will prevent over saturation
     * `Multiply` : the sprite color is multiplied by the background color
     * `Erase` : the sprite color is substracted to the background color
    
 * `filter` : when a sprite is scaled (upscaled or downscaled), by default Heaps will use the nearest pixel in the Tile to display it. This will create a nice pixelated effect for some games, but might not looks good on your game. You can try to set the filter value to true, which will enable bilinear filtering on the sprite, making it looks less sharp and more smooth/blurry.
-* `shaders` : each `Drawable` can have shaders added to modify their display. Shaders are be introduced [here](documentation/h2d/shaders.html).
+* `shaders` : each `Drawable` can have shaders added to modify their display. Shaders are introduced [here](documentation/h2d/shaders.html).
 
 `Drawable` instances have other properties which can be discovered by visiting the [`h2d.Drawable`](https://github.com/ncannasse/heaps/blob/master/h2d/Drawable.hx) API section.

--- a/GPU-Particles.md
+++ b/GPU-Particles.md
@@ -2,7 +2,7 @@
 
 Heaps supports rendering particles on the GPU. This allows for an extremely high amount of particles to be rendered on screen with very little performance impact.
 
-Stting up your GPU particles involves first creating a particle system.
+Setting up your GPU particles involves first creating a particle system.
 
 ```haxe
 //Create a particle system and pass it our 3d scene

--- a/Graphics.md
+++ b/Graphics.md
@@ -11,9 +11,9 @@ var customGraphics = new h2d.Graphics(s2d);
 //specify a color we want to draw with
 customGraphics.beginFill(0xEA8220);
 //Draw a rectangle at 10,10 that is 300 pixels wide and 200 pixels tall
-customGraphics.drawRect(10, 10, 300, 300);
+customGraphics.drawRect(10, 10, 300, 200);
 //End our fill
-customGraphics.endFil();
+customGraphics.endFill();
 ```
 
 The above code will produce the following

--- a/H2D-Shaders.md
+++ b/H2D-Shaders.md
@@ -40,7 +40,7 @@ class SineDeformShader extends hxsl.Shader {
 #### Base 2D values 
 
 For 2D shaders, the following parameters are available in the custom shader. 
-When in doubt, can look these up in `h3d.shader.Base2d` (which you have to import).
+When in doubt, you can look these up in `h3d.shader.Base2d` (which you have to import).
 
 ```haxe
 var spritePosition : Vec4;

--- a/Hello-World.md
+++ b/Hello-World.md
@@ -33,7 +33,7 @@ class Main extends hxd.App {
 		tf.text = "Hello World !";
 	}
 	static function main() {
-		new Hello();
+		new Main();
 	}
 }
 ```
@@ -109,7 +109,7 @@ You can put breakpoints into your Heaps application by clicking in the margin to
 
 ## Compile-and-Run
 
-If you want to make sure that compilation is done every time you press `F5`, you can edit your `.vscode/launch.json` file by adding a `preLanchTask` such as the following example:
+If you want to make sure that compilation is done every time you press `F5`, you can edit your `.vscode/launch.json` file by adding a `preLaunchTask` such as the following example:
 
 ```json
 {

--- a/Lights.md
+++ b/Lights.md
@@ -32,7 +32,7 @@ Directional lights are lights that affect every object with a light enabled mate
 
 The following is an example of how to create a directional light
 
-```
+```haxe
 //Create the directional light by giving it a Vector indicating the direction in which it illuminates and a reference to our 3d scene
 var directionalLight = new h3d.scene.DirLight(new h3d.Vector(0.2, 0.3, -1), s3d);
 //Set the color on the directional light

--- a/Materials.md
+++ b/Materials.md
@@ -2,7 +2,7 @@
 
 Materials are the cornerstone of viewing content in 3d. Your scene can have many objects with geometry but if no materials are applied you will not see anything in your viewport. 
 
-Materials get applied to Meshes.  By default materials area specific color (white) but this can be customized in a variety of ways.
+Materials get applied to Meshes. By default materials are of a specific color (white) but this can be customized in a variety of ways.
 
 ```haxe
 // creates a cube to act as our geometry

--- a/Sprites.md
+++ b/Sprites.md
@@ -1,5 +1,11 @@
 # Sprites
 
+DEPRECATION NOTE : 
+h2d.Sprite is now h2d.Object. Sprite type is still accessible but is actually a typedef of h2d.Object in the API. It has been kept for compatibility reasons.
+The following documentation is not maintained.
+
+
+
 The following properties and methods can be accessed on any Sprite:
 
 * `x` and `y` : the position in pixels relative to the parent Sprite (or in the Scene)


### PR DESCRIPTION
Most of the "errors" (so to speak) are just typos or mistypes. I also fixed two code samples that would not compile.

Added a deprecation note to the Sprites page. In my opinion, it could be removed, given the content of the Sprite.hx file. A new documentation page could be created for h2d.Object. I am available if need be, and if you are okay with the idea.