### PR TITLE
Update docs for FBX Models

### DIFF
--- a/FBX-Models.md
+++ b/FBX-Models.md
@@ -8,20 +8,17 @@ Heaps uses its own internal 3D format called HMD which is faster to load and pro
 
 In order to export a FBX model that can be load to HMD, please make sure to:
 
- * export to FBX 2010 in text format (FBX version 7.x), the FBX binary format is not supported
- * export using Z-up axis
- * export using BakeAnimation, this will make sure your animation is exactly the same it was created
+ * export to FBX 2010 format (FBX version 7.x).
+ * export using Z-up and Y-forward axis.
+ * export using BakeAnimation, this will make sure your animation is exactly the same it was created.
 
 # Restrictions
 
 Some restriction apply to the structure of your models when using FBX export:
 
- * the same Skin cannot be shared among several objects. Merge your objects, using multiple materials if necessary
+ * the same Skin cannot be shared among several objects. Merge your objects, using multiple materials if necessary.
  * try to avoid attaching objects to skin bones. Instead attach by code by using the `follow` property.
-
-# Preview
-
-In order to view your HMD and FBX models and their animations, you can use the Heaps FBXViewer which can be found in the `tools/fbx` directory of Heaps. If you want to see what kind of information is stored in the HMD, you can use `Ctrl+S` while in the viewer to save a text dump of the HMD binary.
+ * not all animation curves are supported. Please make an issue and provide example model if you encount unsupported animation curves.
 
 # Load and display
 
@@ -43,3 +40,35 @@ obj.playAnimation(anim);
 Please note that the HMD library and animations are not cached. If you want to be able to create many instances of the same object in your scene, make sure to cache the values so they can be reused.
 
 A complete example is available in the `samples/skin` directory.
+
+## Using `h3d.prim.ModelCache`
+
+It also possible to load and cache models and animation via `ModelCache` class:
+
+```haxe
+// Create a model cache
+var cache = new h3d.prim.ModelCache();
+// Add a model library to cache.
+// This is optional, because `loadModel` and `loadAnimation` add it to cache automatically.
+// Returns hxd.fmt.hmd.Library
+cache.loadLibrary(hxd.Res.myModel);
+// Create a model instance. Compared to manual model creation, ModelCache loads textures automatically.
+var obj = cache.loadModel(hxd.Res.myModel);
+// Load an animation.
+var anim = cache.loadAnimation(hxd.Res.myModel);
+
+// Clear the cache instance. Note that cache will dispose all cached model textures as well.
+cache.dispose();
+```
+
+This method is more user-friendly and handles library and animations caching internally.
+
+Another thing to note is that how texture loading resolves texture paths. First it tries to load from directly provided `texturePath`, then, if it fails - relative to passed model. E.g. in case of folder structure like that:
+
+```
+texture.png
+models/myModel.fbx
+models/texture.png
+```
+
+It will resolve to top-level `texture.png` instead of `models/texture.png` when loading `hxd.Res.models.myModel` if model requests path as `texture.png`.


### PR DESCRIPTION
* Removed restriction on text-only format, since binary is supported as well now.
* Added Y-forward axis mention.
* Added mention about unsupported curves.
* Added example of `h3d.prim.ModelCache` usage, as it's more preferable option compared to direct mangling with libraries.
* Removed the Preview section, because such tool no longer exists.
* Dots. :)

Maybe better swap ModelCache and direct mangling so preferred solution is above low-level one? 