### PR TITLE
Update: Links extension

### DIFF
--- a/HXSL.md
+++ b/HXSL.md
@@ -85,6 +85,6 @@ There are several shader examples available in the [h3d.shader](api/h3d/shader) 
 
 These shaders mostly uses definitions present in either:
 
-* [Base2d](api/h3d/shader/Base2d.hx) for all 2D display
-* [BaseMesh](api/h3d/shader/BaseMesh.hx) for all 3D display
-* [ScreenShader](api/h3d/shader/ScreenShader.hx) for fullscreen effect / post-process
+* [Base2d](api/h3d/shader/Base2d.html) for all 2D display
+* [BaseMesh](api/h3d/shader/BaseMesh.html) for all 3D display
+* [ScreenShader](api/h3d/shader/ScreenShader.html) for fullscreen effect / post-process


### PR DESCRIPTION
The links had a wrong extension, they only render on `.html` and not on `.hx`
To support both, we could remove the extension, and let the web server resolve the default extension.
I didn't use the extension-less approach as current links (via the navigation) use the `.html` extension.

Sources:
* https://heaps.io/documentation/hxsl.html