### PR TITLE
Update FBX-Models.md to add Blender export options

### DIFF
--- a/FBX-Models.md
+++ b/FBX-Models.md
@@ -12,6 +12,7 @@ In order to export a FBX model that can be load to HMD, please make sure to:
  * export using `Z`-up and `-Y`-forward axis.
  * export using BakeAnimation, this will make sure your animation is exactly the same it was created.
  * note for 3ds Max and Maya: Use Game Exporter instead of standard Export.
+ * note for Blender 2.8: use FBX Units Scale in "Apply Scaling" under Main tab and reduce Simplify to 0 under Animation tab when exporting to FBX. This will preserve the correct armature scaling and prevent animation jitters.
 
 # Restrictions
 


### PR DESCRIPTION
Animations jitter when using Simplify option > 0.
Armature is way bigger than the actual model if Scaling is not set to FBX Units Scale.