### PR TITLE
Update docs

### DIFF
--- a/Drawing-Tiles.md
+++ b/Drawing-Tiles.md
@@ -1,8 +1,26 @@
 # Drawing tiles
 
-This example draws tile layers from a [Tiled](http://www.mapeditor.org/) file (json), it can be used for fast tile rendering.
+Tiles can be drawn with multiple approaches, some of which going to be covered by following example.
 
-The example uses a _tiles.json_ and _tiles.png_ file, that should be put in the resources (`/res`) folder.
+## h2d.Bitmap
+`Bitmap` is a simple container to draw one `Tile`. It's the most basic type, but should be used with caution, as each `Bitmap` causes a draw call.
+
+## h2d.TileGroup
+`TileGroup` allows to batch-draw Tiles beloning to same `Texture` with ability to apply individual tint, transform and alpha to each tile. This class can be used to draw static tiles, but not very well suited for dynamic movement, since it should be cleared and refilled with data each time something should be altered.
+
+### TileGroup hacking
+With `@:privateAccess tileGroup.content` it's possible to access underlying `TileLayerContent` instance and do more fine-tuned geometry operations other than simple rectangles.
+
+## h2d.SpriteBatch
+`SpriteBatch` allows to batch-render Tiles belonging to same `Texture`, but contrary to `TileGroup`, it updates batch data each frame and allows to control each `SpriteElement` individually. Note that by default SpriteBatch does not utilize scale and rotation of SpriteElements and it should be enabled with `hasRotationScale` flag. Same applies to `update` method of SpriteElement - it will be called only when `hasUpdate` flag is set.
+
+### BasicElement and updates
+`h2d.SpriteBatch.BasicElement` is a good example of how `update` method can be utilized. This class provides simple simulation of gravity, friction and velocity.
+
+## Sample
+This example draws tile layers from a [Tiled](http://www.mapeditor.org/) export file (json) using `TileGroup` batching, `Bitmap` for backdrop image and `SpriteBatch` for batch-rendering of moving sprites. 
+
+The example uses a _backdrop.png_, _bunnies.png_, _tiles.json_ and _tiles.png_ files, that should be put in the resources (`/res`) folder. Those files are not included in samples directory.
 
 ```haxe
 class Main extends hxd.App {
@@ -14,6 +32,9 @@ class Main extends hxd.App {
 	
 	override private function init() {
 		super.init();
+		
+		// Add backdrop Bitmap
+		var bitmap = new h2d.Bitmap(hxd.Res.backdrop.toTile(), s2d);
 		
 		// parse Tiled json file
 		var mapData:TiledMapData = haxe.Json.parse(hxd.Res.tiles_json.entry.getText());
@@ -48,7 +69,41 @@ class Main extends hxd.App {
 				}
 			}
 		}
+		
+		// Create raining bunnies with SpriteBatch
+		var bunnies = hxd.Res.bunnies.toTile();
+		var batch = new h2d.SpriteBatch(s2d);
+		batch.hasRotationScale = true;
+		batch.hasUpdate = true;
+		// Note: Does not count as a bunnymark.
+		for (i in 0...100) {
+			var bunny = new Bunny(bunnies);
+			batch.add(bunny);
+			bunny.reset();
+		}
 	}
+}
+
+class Bunny extends h2d.SpriteBatch.SimpleElement {
+	
+	public function new(t:h2d.Tile) {
+		super(t);
+		gravity = 100;
+	}
+	
+	public function reset() {
+		y = -t.height;
+		x = Math.random() * (batch.getScene().width - t.width);
+		scale = 1 + (Math.random() - 0.5) * .1;
+		vx = Math.random() * 60;
+	}
+	
+	override function update(dt:Float) {
+		super.update(dt);
+		if (y > batch.getScene().height) reset();
+		return true;
+	}
+	
 }
 
 // simple type definition for Tile map 

--- a/Full-Game-Samples.md
+++ b/Full-Game-Samples.md
@@ -35,3 +35,10 @@ A strategy game (using mouse UI) with some platformer involved
 - [View sources](https://github.com/ncannasse/ld28)
 
 ![image](https://user-images.githubusercontent.com/1022912/47560681-32884000-d919-11e8-9d6e-47011896927a.png)
+
+### Game Jam games
+
+For more samples of Heaps usage, people published source code for their jam games:
+
+* [Deepnight](https://github.com/deepnight/) github for samples of games based off GameBase template.
+* [Cherry-jam](https://github.com/Yanrishatum/cherry-jam/) repository with several jam entries including 3D games.

--- a/Installation.md
+++ b/Installation.md
@@ -15,6 +15,10 @@ If you plan on testing with HashLink, however, you will need to download the [La
 ```
 haxelib install heaps
 ```
+Or alternatively use github repo for more up-to-date version:
+```
+haxelib git heaps https://github.com/HeapsIO/heaps.git
+```
 
 ## Installing Visual Studio Code + Haxe support
 

--- a/Sound.md
+++ b/Sound.md
@@ -33,3 +33,62 @@ if(musicResource != null){
     musicResource.play(true);
 }
 ```
+
+## Channel, ChannelGroup and SoundGroup
+
+Each Channel instance belong to one SoundGroup and one ChannelGroup that allow to mass-control certain parameters of Channels.  
+### Channel
+Channel instance represents actively playing sound. It's possible to control following parameters on each Channel:
+* `priority`: Priority of the Channel instance (when limiting maximum audible channels, lowest priority Channels get muted when limit is reached)
+* `mute`: Mutes channels. Note that playback still continues when channel is muted.
+* `volume`: Control volume of the Channel.
+* `fadeTo(volume, ?time = 1, ?onEnd: ()->Void)`: Transit channel to specified volume over set period of time with optional callback when transition ends.
+* `addEffect(e:Effect)` / `removeEffect(e:Effect)`: Add and remove effects (see below)
+* `pause`: Allows to temporarily pause sound playback.
+* `duration`: Represents duration of the Sound.
+* `position`: Allow to control playback position of the Channel.
+* `loop`: Sets channel playback to loop.
+* `queue(s:Sound)`: Allows to queue next Sound to play with this Channel instance. It's possible to queue multiple sounds.
+
+### SoundGroup
+Sound groups allow to control volume (multiplier), max audioble channels at once and force mono playback on Channel instances.
+### ChannelGroup
+Channel groups allow to control priority, mute, volume, fading and effects of multiple Channels that bellong to the group. Note that channel priority takes precedence over individual channel priorities.
+
+## Manager
+Audio Manager instance provides API to general management of audio. It can be obtained with `hxd.snd.Manager.get()` call.
+Primary use is access to masterVolume, spatialization listener, as well as default sound and channel groups.
+
+```haxe
+var manager = hxd.snd.Manager.get();
+manager.masterVolume = 0.5;
+manager.masterChannelGroup.addEffect(new hxd.snd.effect.Pitch(0.5));
+manager.masterSoundGroup.maxAudible = 4;
+manager.listener.syncCamera();
+// Stops all Channels that belong to SoundGroup with a name "myGroupName".
+manager.stopByName("myGroupName");
+```
+
+## Effects
+
+When playing a sound, it's possible to attach effects to the Channel or ChannelGroup instance. Due to backend difference, some backends may not support all effect types. Following sample showcases usage of pitch effect:
+
+```haxe
+var sound = Res.my_sound.play();
+// 0.5 pitch would make it sound slowed down.
+var pitch = new hxd.snd.Effect(0.5);
+sound.addEffect(pitch);
+// Returns first effects with specified type
+trace(sound.getEffect(hxd.snd.Effect));
+// Remove effect from channel
+sound.removeEffect(pitch);
+```
+
+### Platform-specific limitations
+
+#### HTML5
+* Pitch: Due to how WebAudio works, changing pitch gradually can lead to audio cuts. This cannot be avoided due to pitch being applied only once in 128 samples and impossibility to obtain accurate current sample of audio buffer.
+* Spatialization: Velocity is not supported.
+
+#### OpenAL (Hashlink)
+* Spatialization: Only mono sounds are supported. (Use SoundGroup.mono to force mono playback)

--- a/Sound.md
+++ b/Sound.md
@@ -1,6 +1,6 @@
 # Sound
 
-Heaps provides sound management. Heaps supports 3 different formats (WAV, MP3, OGG).  The availability of the formats depend on the platform. You can determine which formats are supported using the following example:
+Heaps provides sound management. Heaps supports 3 different formats (WAV, MP3, OGG).  The availability of the formats depend on the platform (see [Resource manager](https://github.com/HeapsIO/heaps/wiki/Resource-Management#target-specific-quirks) page for details). You can determine which formats are supported using the following example:
 
 ```haxe
 if(hxd.res.Sound.supportedFormat(Mp3)){

--- a/Text.md
+++ b/Text.md
@@ -16,6 +16,39 @@ s2d.addChild(tf);
 
 For each font family you need a different font file, but you can tint them with code, using `textColor`. 
 
+### HtmlText usage
+Along with regular Text, there is also an [h2d.HtmlText](https://heaps.io/api/h2d/HtmlText.html) class that allows to use simple html markdown for rich text.
+
+#### Supported HTML tags and their attributes
+
+* `<font>`: Alters font parameters for tag contents.
+  * `face="myFontFace"`: Sets different font face. See remarks about font loading below.
+  * `color="#880088"`: Sets text color. Should be in hexadecimal format.
+  * `opacity="0.5"`: Set text opacity. Value should be between 0 and 1.
+* `<p>`: Inserts line-breaks before and after paragraph and allows to control text alignment.
+  * `align="center"`: Set text align for tag contents. Valid values are: `left`, `right`, `center`, `multiline-center`, `multiline-right`.
+* `<b>`: Alias to `<font face="bold">`
+* `<i>`: Alias to `<font face="italic">`
+* `<br/>`: Creates a line-break.
+* `<img>`: Inserts an image.
+  * `src="myimage.png"`: Name of the image to load. See remarks about image loading beloew.
+
+#### Font and image loading
+HtmlText does not use Resource Manager to load fonts or images. Loading is performed by setting the callback methods:
+```haxe
+// Global callbacks that work for all HtmlText instances.
+HtmlText.defaultLoadImage = function( url : String ) : h2d.Tile { return null; }
+HtmlText.defaultLoadFont = function( name : String ) : h2d.Font { return null; }
+HtmlText.defaultFormatText = function ( text : String ) : String { return text; }
+// Per-instance callbacks that allow to customize each instance
+// with individual scope.
+htmlText.loadImage = function( url : String ) : h2d.Tile { return null; }
+htmlText.loadFont = function( name : String ) : h2d.Font { return null; }
+htmlText.formatText = function ( text : String ) : String { return text; }
+```
+It's up to user how to implement resource loading. Please note, that there is no tile/font caching on HtmlText side.  
+Lastly, `formatText` allows to modify and/or validate text contents when it's changed.
+
 ## Font creation
 
 If you want to use custom fonts, other than the Default one, you need to create a `.fnt` file and put it into your `res` directory.  
@@ -45,13 +78,16 @@ In the BMFont-tool, use these settings:
   * Texture: Png
 * _File_ → _Save bitmap font as.._ 
   * Put in your Heaps project under `./res/fonts/myFontName.fnt` 
+* _Note:_ Multi-texture fnt files are not supported, ensure that there is only one font texture per fnt file.
 
 ### Convert font to bitmap font using Littera
 
-In [Littera](http://www.kvazars.com/littera/), use these settings:
+Due to browsers no longer supporting Flash, Littera can be ran only by older browser versions [here](http://www.kvazars.com/littera/) 
+or trough standalone flash player by running [swf file](http://www.kvazars.com/littera/littera.swf) directly.  
+Use following settings:
 
 * Settings in the left column
-  * Update a font from your computer with _Select Font_ big button
+  * Update a font from your computer with _Select Font_ button
   * Choose size 
   * Set the values:
     * Select what glyphs do you want to export.
@@ -63,7 +99,7 @@ In [Littera](http://www.kvazars.com/littera/), use these settings:
   * Format: Either `XML (.fnt)` or `Text (.fnt)`
   * Default values are fine for Heaps
   * Press _Export_ start the downloading process.
-  * Unzip the file an put it's content in your Heaps project under `./res/fonts/` 
+  * Unzip the file and put it's content in your Heaps project under `./res/fonts/` 
 * If you renamed the files, don't forget to update reference to font texture in `pages` section of `.fnt` file.
 
 ### Using libgdx Hiero
@@ -73,6 +109,10 @@ In [Littera](http://www.kvazars.com/littera/), use these settings:
 * Refer to this instruction to generate SDF fonts: [Distance Field Fonts](/libgdx/libgdx/wiki/Distance-field-fonts)
 * Refer to this page for general instruction on Hiero usage: [Hiero](/libgdx/libgdx/wiki/Hiero)
 
+### Using fontgen tool
+
+[Fontgen](https://github.com/Yanrishatum/fontgen/) is a command-line utility to generate fonts including SDF and MSDF formats. It was written specifically for Heaps and ShiroGames.  
+Utility is strictly command-line with config files, please refer to readme file.
 
 ### Be creative with bitmapfonts
 
@@ -90,11 +130,12 @@ Once the font is ready, you can use it for your Text:
 * load it using `hxd.Res.fonts.myFont.toFont()`
 * create an `h2d.Text` using this font
 
+### SDF / MSDF
 For SDF fonts you need to load fonts slightly differently.
 
 * Instead of `toFont()` use `toSdfFont(size, channel, alphaCutoff, smoothing)`
   * `size` will represent desired font size.
-  * `channel` tells from which texture channel SDF shader should take the information.
+  * `channel` tells which texture channel SDF shader should take the information from.
   * `alphaCutoff` will set the border of a glyph, with `0.5` being default value.
   * `smoothing` controls the amount of antialiasing applied to glyph borders. 
 * Set `Text.smoothing` to `true`, otherwise SDF won't render properly.


### PR DESCRIPTION
* Added git installation of Heaps to installation guide.
* Added links to jam games to game samples. Those at least feature somewhat functional 3D game sources.
* Drastically improved Sound docs.
* Added mention of fontgen to Text docs.
* Updated Littera information, since Flash is being driven out of browsers (and tool is still pretty good)
* Added HtmlText docs.
* Added more information about ways to draw tiles.
* Also added mention that `samples` folder does not contain files shown in sample code. People get confused about that a lot.

Now if only people would start reading the docs first before asking.