### PR TITLE
Typo on the SDL library installation command

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -62,7 +62,7 @@ Using `haxelib install` in the command line, install the following items:
 
 ```
 haxelib install hlopenal
-haxelib install hsdl
+haxelib install hlsdl
 haxelib install hldx
 ```
 


### PR DESCRIPTION
The letter 'l' is missing on the SDL library installation command:
Fixed to: "haxelib install hlsdl"