### PR TITLE
Improve small details throughout docs.

### DIFF
--- a/DomKit.md
+++ b/DomKit.md
@@ -1,23 +1,23 @@
 DomKit is a library that can be used together with Heaps to create complex UI and integrate custom 2D components into it.
 
-You should get install it first using:
+You should install it first using:
 
 `haxelib git domkit https://github.com/HeapsIO/domkit.git`
 
-You can then add it to your project libraries with `-lib domkit` (together with `-lib heaps`)
+You can then add it to your project libraries with `-lib domkit` (together with `-lib heaps`).
 
-You can see compile and run the corresponding [Heaps Sample](https://github.com/HeapsIO/heaps/blob/master/samples/Domkit.hx)
+You can see, compile and run the corresponding [Heaps Sample](https://github.com/HeapsIO/heaps/blob/master/samples/Domkit.hx).
 
 # Using Heaps Components
 
-In order to use Domkit to create a heaps components, you simply need to implements `h2d.domkit.Object` and define your document in the `SRC` static as the following sample shows:
+In order to use Domkit to create a heaps component, you simply need to implement `h2d.domkit.Object` and define your document in the `SRC` static variable, as the following sample shows:
 
 ```haxe
 class SampleView extends h2d.Flow implements h2d.domkit.Object {
 
-    static var SRC = 
-        <sample-view layout="vertical"> 
-            Hello World! 
+    static var SRC =
+        <sample-view layout="vertical">
+            Hello World!
             <bitmap src={tile} public id="mybmp"/>
         </sample-view>
 
@@ -42,11 +42,11 @@ You can then apply CSS at runtime to your document by using the following code:
 ```haxe
 var style = new h2d.domkit.Style();
 // resource referencing res/style.css (see Heaps Resources documentation)
-style.load(hxd.Res.style); 
+style.load(hxd.Res.style);
 style.addObject(view);
 ```
 
-Here's an example CSS that can apply to previous view:
+Here's an example CSS that can be applied to the previous view:
 
 ```css
 .box {
@@ -58,6 +58,7 @@ Here's an example CSS that can apply to previous view:
 ## Runtime CSS reload
 
 In order to get runtime CSS reload you need to:
+
 * use a `hxd.Res.initLocal()` so you use a local filesystem to load resources. This is only available to some platforms such as HashLink
 * enable resources live update with `hxd.Res.LIVE_UPDATE = true;`
 
@@ -71,24 +72,24 @@ You can add an init macro that will process at compile time your CSS and will re
 domkit.Macros.checkCSS("res/style.css");
 ```
 
-Or my adding to your Haxe compilation parameters :
+Or by adding to your Haxe compilation parameters:
 
-``` 
+```
 --macro domkit.Macros.checkCSS('res/style.css')
 ```
 
-Please note that since each CSS property can be used by different components in different ways, and since you can't always tell by CSS rules on which component type the property will be applied, we only check that the property is valid and the CSS accepted for one of the components that defines it.
+Please note that since each CSS property can be used by different components in different ways, and since you can't always tell by CSS rules on which component type the property will be applied, we only check that the property is valid and the CSS accepted for one of the components that define it.
 
 # Accessing the DOM
 
-When compiled with `-lib domkit`, each `h2d.Object` will have an extra `dom : domkit.Properties` field that can be used for changing the state of the object wrt CSS :
+When compiled with `-lib domkit`, each `h2d.Object` will have an extra `dom : domkit.Properties` field that can be used for changing the state of the object wrt CSS:
 
 ```haxe
 mybmp.dom.addClass("myclass");
 mybmp.dom.hover = true;
 ```
 
-More code can be found in the Heaps Domkit sample.
+More code can be found in the [Heaps Domkit examples](https://github.com/HeapsIO/heaps/blob/master/samples/Domkit.hx).
 
 # Domkit Inspector
 
@@ -98,16 +99,17 @@ You can inspect your components by enabling the domkit inspector. This is done u
 style.allowInspect = true;
 ```
 
-You can then using middle mouse button click anytime to enable/disable domkit inspector. Move your mouse over any component to see its name, id, classes and properties. You can use the mouse wheel to browse the component hierarchy. Maintaining `Ctrl` while clicking will also display the hierarchy in a separate tree-view.
+You can then use the middle mouse button click anytime to enable/disable domkit inspector. Move your mouse over any component to see its name, id, classes and properties. You can use the mouse wheel to browse the component hierarchy. Maintaining `Ctrl` while clicking will also display the hierarchy in a separate tree-view.
 
 ![image](https://haxe.org/img/blog/2020-04-06-shirogames-stack/domkit.png)
 
 # Defining custom Components
 
 In order to define custom components, you need to:
-* implements `h2d.domkit.Object` (if not already inherited from your superclass)
+
+* implement `h2d.domkit.Object` (if not already inherited from your superclass)
 * add `@:p` for each property you wish to expose to domkit markup/CSS
-* you can add `@:uiComp("name")` metadata in order to customize the component name
+* optionally add `@:uiComp("name")` metadata in order to customize the component name
 
 Here's a small example:
 ```haxe
@@ -127,7 +129,7 @@ class MyComp extends h2d.Flow implements h2d.domkit.Object {
     function set_style(s) {
         this.style = s;
         // ....
-        return s;    
+        return s;
     }
 
 }
@@ -141,11 +143,11 @@ It is now possible to use your component from any document `SRC` by doing the fo
 
 ## Components with SRC
 
-It is possible to have a component that also have a SRC. In that case, you need to reference the component name in your SRC root node name so its properties can be applied correctly.
+It is possible to have a component that also has an SRC. In that case, you need to reference the component name in your SRC root node name so its properties can be applied correctly.
 
 ## Components resolution
 
-Components are resolved by name by adding `Comp` to the capitalized component name. For instance `<something/>` will try to load `SomethingComp` class from local context.
+Components are resolved by name by adding `Comp` to the capitalized component name. For instance `<something/>` will try to load `SomethingComp` class from the local context.
 
 If you wish to customize this name resolution, you can use an init macro such as:
 
@@ -158,18 +160,18 @@ class Init {
 }
 ```
 
-In the path, the `$` character is the capitalized component name. 
+In the path, the `$` character is the capitalized component name.
 By default `"$Comp"` is a registered path in Heaps.
 
 ## Custom CSS parsing
 
-Some properties requires custom parsing. For instance color codes, padding boxes, etc.
-You can specify which parser method to use by changing `@:p` metadata in the following way:
+Some properties require custom parsing, like color codes, padding boxes, etc.
+You can specify which parser method to use by changing the `@:p` metadata in the following way:
 
 ```haxe
 // will use parseTile CSS parser method
 @:p(tile) public var tile : h2d.Tile;
-``` 
+```
 
 You can use any identifier that is allowed in the current CSS parser. The default Heaps parser can be found in `h2d/domkit/BaseComponents.hx`
 
@@ -197,8 +199,9 @@ class MyComp extends h2d.Flow implements h2d.domkit.Object {
 }
 ```
 
-And it means you can now use values this way in attributes or CSS:
-```
+With this you can now use custom values in attributes or CSS:
+
+```jsx
 <my values="1,2,3"/>
 ```
 
@@ -209,17 +212,17 @@ Domkit markup allows the following syntaxes.
 ```jsx
 <node attr="value"/>
 ```
-A component with a CSS attribute value. Please note that the value has to be valid CSS and is parsed then interpreted based on the components custom parsing rules in order to be translated to the actual runtime value for the corresponding node property.
+A component with a CSS attribute value. Please note that the value has to be valid CSS and is parsed then interpreted based on the component's custom parsing rules in order to be translated to the actual runtime value for the corresponding node property.
 
 ```jsx
 <node attr={expr}/>
 ```
-Set the attribute based on an Haxe code expression. Unlike previous syntax, here the expression must directly evaluates to the property runtime value, without going through CSS interpretation.
+Set the attribute based on a Haxe code expression. Unlike the previous syntax, here the expression must directly evaluate to the property runtime value, without going through CSS interpretation.
 
 ```jsx
 <node attr/>
 ```
-A shortcut for `attr="true"`. Allows to easily set boolean attributes
+A shortcut for `attr="true"`. Allows to easily set boolean attributes.
 
 ```jsx
 <node id="identifier"/>
@@ -239,7 +242,7 @@ Creates an Array of components on the current class and push the component value
 ```jsx
 <node(value1,value2,value3)/>
 ```
-Allows to pass constructor arguments to your custom component. ATM only Haxe values are allowed to be passed, DomKit does not allow passing CSS values to constructor arguments.
+Allows to pass constructor arguments to your custom component. At the moment only Haxe values are allowed to be passed, DomKit does not allow passing CSS values to constructor arguments.
 
 ```jsx
 <flow>
@@ -263,14 +266,14 @@ When just a Haxe variable identifier is injected into the document content, we a
 // commented <a/></a>
 </some>
 ```
-A single line comment within body
+A single line comment within body.
 
 ```jsx
 <some>
 <a> /* commented <a/></a> */ </a>
 </some>
 ```
-A multiline / delimited comment within body
+A multiline / delimited comment within body.
 
 ```jsx
 @something
@@ -280,40 +283,40 @@ A multiline / delimited comment within body
 @custom.path(value1,value2,value3)
 ```
 These are markup macros that can be processed in a custom manner by setting `domkit.Macros.processMacro` in an init macro. It allows you to process identifier path and arguments (Haxe expressions) to return some markup syntax that will be then processed.
- 
+
 # Heaps CSS reference
 
 This is the complete documentation for allowed CSS attributes for native Heaps components.
 
 ## object
 
-See [corresponding heaps documentation](https://heaps.io/api/h2d/Object.html)
+See [corresponding heaps documentation](https://heaps.io/api/h2d/Object.html).
 
 ```
 x : 0.5
 ```
-x position
+x position.
 
 ```
 y : 0.5
 ```
-y position
+y position.
 
 ```
 alpha : 0.5
 ```
-opacity
+opacity.
 
 ```
 rotation : 45
 ```
-rotation (unlike Heaps, value is expressed in degrees, not radians)
+rotation (unlike Heaps, value is expressed in degrees, not radians).
 
 
 ```
 visible : true
 ```
-toggle visibility
+toggle visibility.
 
 ```
 scale : 2.5
@@ -321,18 +324,18 @@ scale : 0.5 0.8
 scale-x : 0.5
 scale-y : 2
 ```
-Uniform or X/Y scaling
+Uniform or X/Y scaling.
 
 ```
 blend : none
 blend : alpha (default)
 blend : add
 ```
-Blendmode
+Blendmode.
 
 ### Flow properties
 
-These properties are only valid when the object parent is a `<flow/>` (see [corresponding heaps documentation](https://heaps.io/api/h2d/FlowProperties.html))
+These properties are only valid when the parent object is a `<flow/>` (see [corresponding heaps documentation](https://heaps.io/api/h2d/FlowProperties.html)).
 
 ```
 margin : 5
@@ -343,7 +346,7 @@ margin-bottom : 5
 margin-right : 0
 margin : 10 20 5 0
 ```
-Margins around the object (these are FlowProperties.padding values)
+Margins around the object (these are FlowProperties.padding values).
 
 ```
 align : left
@@ -352,13 +355,13 @@ align : bottom right
 halign : right
 valign : bottom
 ```
-Allows to override alignment for a single object in the flow
+Allows to override alignment for a single object in the flow.
 
 ```
 position : absolute
 position : auto
 ```
-Tells if the object position is automatically set by the flow or manually managed
+Tells if the object position is automatically set by the flow or manually managed.
 
 ```
 offset : 10 20
@@ -375,85 +378,85 @@ Gives minimal width/height to the object wrt flow calculus.
 
 ## drawable
 
-See [corresponding heaps documentation](https://heaps.io/api/h2d/Drawable.html)
+See [corresponding heaps documentation](https://heaps.io/api/h2d/Drawable.html).
 
 ```
 color : #ff0000
 color : #f00
 ```
-Color tint 
+Color tint.
 
 ```
 smooth : true
 smooth : auto
 ```
-Toggles bilinear filtering or keep auto mode
+Toggles bilinear filtering or keep auto mode.
 
 ```
 tile-wrap : true
 ```
-Enables tile wrapping
+Enables tile wrapping.
 
 ## bitmap
 
-See [corresponding heaps documentation](https://heaps.io/api/h2d/Bitmap.html)
+See [corresponding heaps documentation](https://heaps.io/api/h2d/Bitmap.html).
 
 ```
 src : url("my/tile.png")
 src : #f00 20 20
 ```
-Load the tile or creates one with the specific color and size
+Loads the tile or creates one with the specific color and size.
 
 ## text
 
-See [corresponding heaps documentation](https://heaps.io/api/h2d/Text.html)
+See [corresponding heaps documentation](https://heaps.io/api/h2d/Text.html).
 
 ```
 text : "some text"
 ```
-Text content to display
+Text content to display.
 
 ```
 font : url("path/to/bitmapfont.fnt")
 ```
-Set font to be used for display
+Set font to be used for display.
 
 ```
 letter-spacing : 2
 ```
-Space between letters
+Space between letters.
 
 ```
 line-spacing : 4
 ```
-Space between lines
+Space between lines.
 
 ```
 max-width : none
 max-width : 300
 ```
-Maximum width for auto text wrapping
+Maximum width for auto text wrapping.
 
 ```
 text-align : left
 text-align : right
 text-align : middle
 ```
-Alignment of the text (usually not used within a flow, instead use the `align` property)
+Alignment of the text (usually not used within a flow, instead use the `align` property).
 
 ```
 text-shadow : 1.5 2 #f00 0.5
 ```
-Set a drop shadow for the text (dx,dy,color,alpha)
+Set a drop shadow for the text (dx,dy,color,alpha).
 
 ```
 text-color : #f00
 ```
-Changes text color
+Changes text color.
 
 ## flow
 
-See [corresponding heaps documentation](https://heaps.io/api/h2d/Flow.html)
+See [corresponding heaps documentation](https://heaps.io/api/h2d/Flow.html).
 
 ```
 width : auto
@@ -461,7 +464,7 @@ width : 500
 min-width : 450
 max-height : none
 ```
-Set min/max width/height constraints
+Set min/max width/height constraints.
 
 ```
 background : url("my/resource")
@@ -469,7 +472,7 @@ background : url("my/resource") 5 8
 background : #f00
 background : transparent
 ```
-Flow background with optional borderWidth/Height
+Flow background with optional borderWidth/Height.
 
 ```
 background : tile("my/resource",5)
@@ -477,24 +480,24 @@ background-tile-pos: 3
 background : tile("my/resource",5,8)
 background-tile-pos: 3 7
 ```
-Flow background with split tile (vertical and optional horizontal frames) and separate attribute for setting the sub tile
+Flow background with split tile (vertical and optional horizontal frames) and separate attribute for setting the sub tile.
 
 ```
 debug : true
 ```
-Display debug lines
+Display debug lines.
 
 ```
 layout : vertical
 layout : horizontal
 layout : stack
 ```
-Sets the flow in either layout display mode
+Sets the flow in either layout display mode.
 
 ```
-multline : true
+multiline : true
 ```
-Activates multiline
+Activates multiline.
 
 ```
 padding : 5
@@ -505,13 +508,13 @@ padding-bottom : 5
 padding-right : 0
 padding : 10 20 5 0
 ```
-Padding values around contained elements
+Padding values around contained elements.
 
 ```
 hspacing : 10
 vspacing : 5
 ```
-Horizontal and vertical spacing between contained elements
+Horizontal and vertical spacing between contained elements.
 
 ```
 content-align : left
@@ -519,4 +522,4 @@ content-align : right top
 content-valign : middle
 content-halign : right
 ```
-Changes horizontal/vertical default alignment for contained elements (flow horizontalAlign/verticalAlign)
+Changes horizontal/vertical default alignment for contained elements (flow horizontalAlign/verticalAlign).

--- a/Drawable.md
+++ b/Drawable.md
@@ -6,16 +6,16 @@ Each Drawable (including [`h2d.Bitmap`](https://github.com/ncannasse/heaps/blob/
 
 * `alpha` : this will change the amount of transparency your drawable is displayed with. For instance a value of 0.5 will display a Tile with 50% opacity.
 * `color` : color is the color multiplier of the drawable. You can access its individual channels with (r,g,b,a) components. It is initialy set to white (all components are set to 1.). Setting for instance the (r,g,b) components to 0.5 will make the tile appear darker.
-* `blendMode` : the blend mode tells how the drawable gets composited with the background color when it is drawn on the screen. The background color refers to the screen content at the time the sprite is being drawn. This can be another sprite content if it was drawn before at the same position. The following blend mode values are available :  
-	
+* `blendMode` : the blend mode tells how the drawable gets composited with the background color when it is drawn on the screen. The background color refers to the screen content at the time the sprite is being drawn. This can be another sprite content if it was drawn before at the same position. The following blend mode values are available :
+
     * `Alpha` (default) : the drawable blends itself with the background using its alpha value. An opaque pixel will erase the background, a fully transparent one will be ignored.
     * `None` : this disable the blending with the background. Alpha channel is ignored and the color is written as-is. This offers the best display performances for large backgrounds that have nothing displayed behind them
     * `Add` : the drawable color will be added to the background, useful for creating explosions effects or particles for instance.
     * `SoftAdd` : similar to Add but will prevent over saturation
     * `Multiply` : the sprite color is multiplied by the background color
     * `Erase` : the sprite color is substracted to the background color
-   
-* `filter` : when a sprite is scaled (upscaled or downscaled), by default Heaps will use the nearest pixel in the Tile to display it. This will create a nice pixelated effect for some games, but might not looks good on your game. You can try to set the filter value to true, which will enable bilinear filtering on the sprite, making it looks less sharp and more smooth/blurry.
+
+* `filter` : when a sprite is scaled (upscaled or downscaled), by default Heaps will use the nearest pixel in the Tile to display it. This will create a nice pixelated effect for some games, but might not look good on your game. You can try to set the filter value to true, which will enable bilinear filtering on the sprite, making it look less sharp and more smooth/blurry.
 * `shaders` : each `Drawable` can have shaders added to modify their display. Shaders are introduced [here](https://github.com/HeapsIO/heaps/wiki/H2D-Shaders).
 
 `Drawable` instances have other properties which can be discovered by visiting the [`h2d.Drawable`](https://github.com/ncannasse/heaps/blob/master/h2d/Drawable.hx) API section.

--- a/Drawing-Tiles.md
+++ b/Drawing-Tiles.md
@@ -1,26 +1,26 @@
 # Drawing tiles
 
-Tiles can be drawn with multiple approaches, some of which going to be covered by following example.
+Tiles can be drawn with multiple approaches, some of which are going to be covered by following examples.
 
 ## h2d.Bitmap
 `Bitmap` is a simple container to draw one `Tile`. It's the most basic type, but should be used with caution, as each `Bitmap` causes a draw call.
 
 ## h2d.TileGroup
-`TileGroup` allows to batch-draw Tiles beloning to same `Texture` with ability to apply individual tint, transform and alpha to each tile. This class can be used to draw static tiles, but not very well suited for dynamic movement, since it should be cleared and refilled with data each time something should be altered.
+`TileGroup` allows to batch-draw Tiles belonging to the same `Texture`, with the ability to apply individual tint, transform and alpha to each tile. This class can be used to draw static tiles, but is not very well suited for dynamic movement, since it should be cleared and refilled with data each time something should be altered.
 
 ### TileGroup hacking
 With `@:privateAccess tileGroup.content` it's possible to access underlying `TileLayerContent` instance and do more fine-tuned geometry operations other than simple rectangles.
 
 ## h2d.SpriteBatch
-`SpriteBatch` allows to batch-render Tiles belonging to same `Texture`, but contrary to `TileGroup`, it updates batch data each frame and allows to control each `SpriteElement` individually. Note that by default SpriteBatch does not utilize scale and rotation of SpriteElements and it should be enabled with `hasRotationScale` flag. Same applies to `update` method of SpriteElement - it will be called only when `hasUpdate` flag is set.
+`SpriteBatch` allows to batch-render Tiles belonging to the same `Texture`, but contrary to `TileGroup`, it updates batch data each frame and allows to control each `SpriteElement` individually. Note that by default SpriteBatch does not use scale and rotation of SpriteElements and it should be enabled with the `hasRotationScale` flag. The same applies to the `update` method of SpriteElement — it will be called only when the `hasUpdate` flag is set.
 
 ### BasicElement and updates
-`h2d.SpriteBatch.BasicElement` is a good example of how `update` method can be utilized. This class provides simple simulation of gravity, friction and velocity.
+`h2d.SpriteBatch.BasicElement` is a good example of how the `update` method can be used. This class provides simple simulation of gravity, friction and velocity.
 
 ## Sample
-This example draws tile layers from a [Tiled](http://www.mapeditor.org/) export file (json) using `TileGroup` batching, `Bitmap` for backdrop image and `SpriteBatch` for batch-rendering of moving sprites. 
+This example draws tile layers from a [Tiled](http://www.mapeditor.org/) export file (json) using `TileGroup` batching, `Bitmap` for backdrop image and `SpriteBatch` for batch-rendering of moving sprites.
 
-The example uses a _backdrop.png_, _bunnies.png_, _tiles.json_ and _tiles.png_ files, that should be put in the resources (`/res`) folder. Those files are not included in samples directory.
+The example uses files _backdrop.png_, _bunnies.png_, _tiles.json_ and _tiles.png_. These files should be put in the resources (`/res`) folder. They are not included in samples directory.
 
 ```haxe
 class Main extends hxd.App {
@@ -29,39 +29,39 @@ class Main extends hxd.App {
 		hxd.Res.initEmbed();
 		new Main();
 	}
-	
+
 	override private function init() {
 		super.init();
-		
+
 		// Add backdrop Bitmap
 		var bitmap = new h2d.Bitmap(hxd.Res.backdrop.toTile(), s2d);
-		
+
 		// parse Tiled json file
 		var mapData:TiledMapData = haxe.Json.parse(hxd.Res.tiles_json.entry.getText());
-		
+
 		// get tile image (tiles.png) from resources
-		var tileImage  = hxd.Res.tiles_png.toTile();
-		
+		var tileImage = hxd.Res.tiles_png.toTile();
+
 		// create a TileGroup for fast tile rendering, attach to 2d scene
 		var group = new h2d.TileGroup(tileImage, s2d);
-		
+
 		var tw = mapData.tilewidth;
 		var th = mapData.tileheight;
 		var mw = mapData.width;
 		var mh = mapData.height;
-		
+
 		// make sub tiles from tile
 		var tiles = [
 			 for(y in 0 ... Std.int(tileImage.height / th))
 			 for(x in 0 ... Std.int(tileImage.width / tw))
 			 tileImage.sub(x * tw, y * th, tw, th)
 		];
-		
+
 		// iterate on all layers
 		for(layer in mapData.layers) {
 			// iterate on x and y
 			for(y in 0 ... mh) for (x in 0 ... mw) {
-				// get the tile id at the current position 
+				// get the tile id at the current position
 				var tid = layer.data[x + y * mw];
 				if (tid != 0) { // skip transparent tiles
 					// add a tile to the TileGroup
@@ -69,7 +69,7 @@ class Main extends hxd.App {
 				}
 			}
 		}
-		
+
 		// Create raining bunnies with SpriteBatch
 		var bunnies = hxd.Res.bunnies.toTile();
 		var batch = new h2d.SpriteBatch(s2d);
@@ -85,27 +85,26 @@ class Main extends hxd.App {
 }
 
 class Bunny extends h2d.SpriteBatch.SimpleElement {
-	
+
 	public function new(t:h2d.Tile) {
 		super(t);
 		gravity = 100;
 	}
-	
+
 	public function reset() {
 		y = -t.height;
 		x = Math.random() * (batch.getScene().width - t.width);
 		scale = 1 + (Math.random() - 0.5) * .1;
 		vx = Math.random() * 60;
 	}
-	
+
 	override function update(dt:Float) {
 		super.update(dt);
 		if (y > batch.getScene().height) reset();
 		return true;
 	}
-	
 }
 
-// simple type definition for Tile map 
+// simple type definition for Tile map
 typedef TiledMapData = { layers:Array<{ data:Array<Int>}>, tilewidth:Int, tileheight:Int, width:Int, height:Int };
 ```

--- a/H2D-Introduction.md
+++ b/H2D-Introduction.md
@@ -1,4 +1,4 @@
-# Introduction 
+# Introduction
 
 ## Concepts
 
@@ -26,7 +26,7 @@ class Myapp extends hxd.App
         s2d;                            // the current scene
         var myscene = new h2d.Scene();  // create a new scene
         setScene(myscene);              // set it as the current scene
-        s2d;                            // is now newscene
+        s2d;                            // is now myscene
 
         var myobj2 = new h2d.Object();
         s2d.addChild(myobj2);
@@ -51,7 +51,6 @@ A **Tile** (represented by [h2d.Tile](https://heaps.io/api/h2d/Tile.html)) is a 
 
 ```haxe
 var mycolortile = h2d.Tile.fromColor(0xFF00FF, 100, 100, 1);
-var myimagetile = myimage.toTile();
 ```
 
 #### Tile Pivot

--- a/HXSL.md
+++ b/HXSL.md
@@ -2,7 +2,7 @@
 
 ## HXSL stands for "Haxe Shader Language"
 
-It's a shader language that follows entirely the OpenGL shader language ([GLSL](https://en.wikipedia.org/wiki/OpenGL_Shading_Language)) specification, but which uses Haxe syntax, allowing you to write directly your shader in your Haxe source code.
+It's a shader language that follows entirely the OpenGL shader language ([GLSL](https://en.wikipedia.org/wiki/OpenGL_Shading_Language)) specification, but which uses Haxe syntax, allowing you to write your shaders directly in your Haxe source code.
 
 Vertex shaders are used for transforming and projecting each geometry point into 2D space and set up "variables" that will be interpolated on a per-pixel basis. This can be used by the pixel shader.
 
@@ -38,7 +38,7 @@ This shader defines:
 
 ## Variable kind
 
-There are several type of variables in HXSL:
+There are several types of variables in HXSL:
 
 - `@input` are vertex attributes input values
 - `@param` are per-shader-instance shader parameters / uniforms
@@ -52,7 +52,7 @@ There are several type of variables in HXSL:
 
 Unlike other shader models (GLSL, HLSL, etc.), HXSL allows several shaders to be **linked ** together at runtime, allowing you to split your shader into several distinct effects that can be enabled/disabled easily, without having to maintain a single "Uber Shader" with all the possible combinations.
 
-For instance, this is an shader that will affect all normals based on the previous shader:
+For instance, this is a shader that will affect all normals based on the previous shader:
 
 ```haxe
 class MyEffect extends hxsl.Shader {
@@ -65,18 +65,18 @@ class MyEffect extends hxsl.Shader {
 }
 ```
 
-The effect can be added to each material **list of shaders**. 
+The effect can be added to each material **list of shaders**.
 
-HXSL will then compile this list into a single shader instance, based on a desired list of **outputs**. 
+HXSL will then compile this list into a single shader instance, based on a desired list of **outputs**.
 
-For instance, we can select either the `output.color` or `output.normal` declared in `MyShader` to either write the normal value or the color value (or we could select both if we want to write to several textures at once, like in [MRT](https://en.wikipedia.org/wiki/Multiple_Render_Targets))
+For instance, we can select either the `output.color` or `output.normal` declared in `MyShader` to either write the normal value or the color value (or we could select both if we want to write to several textures at once, like in [MRT](https://en.wikipedia.org/wiki/Multiple_Render_Targets)).
 
 After we know the list of the shaders and the desired output, HXSL will be linking the shaders together, ensuring that all variables read have been previously written (for instance `MyEffect` requires a `transformedNormal` variable that has been written by another shader in the pipeline).
 
 Once linking is finished, HXSL will be optimizing out all the unused parts, such as:
 
 * branches implying `@const` variables are optimized out when they are unreachable
-* unused variables, unused textures, operations not performing any side effect that affects one of the outputs
+* unused variables, unused textures, operations not performing any side effects that affect one of the outputs
 
 The final resulting shader will then be compiled to the target platform native shader language (HXSL currently supports GLSL for OpenGL, HLSL for DirectX 11+, AGAL for AdobeAir, and PSSL for Sony PS4).
 
@@ -84,7 +84,7 @@ The final resulting shader will then be compiled to the target platform native s
 
 There are several shader examples available in the [h3d.shader](api/h3d/shader) package.
 
-These shaders mostly uses definitions present in either:
+These shaders mostly use definitions present in either:
 
 * [Base2d](api/h3d/shader/Base2d.html) for all 2D display
 * [BaseMesh](api/h3d/shader/BaseMesh.html) for all 3D display

--- a/Hello-World.md
+++ b/Hello-World.md
@@ -96,7 +96,7 @@ Now, in your project directory, create a file `index.html` and add the following
 	<title>Hello Heaps</title>
 	<style>
 		body { margin:0;padding:0;background-color:black; }
-		canvas#webgl { width:100%;height:100%; } 
+		canvas#webgl { width:100%;height:100%; }
 	</style>
 </head>
 <body>
@@ -116,6 +116,10 @@ To compile without running, hit `Ctrl-Shift-B` and select `haxe : active configu
 If everything works well, you should now have both `hello.js` and `hello.js.map` files created in your project folder:
 
 ![image](https://user-images.githubusercontent.com/1022912/45916520-e6ecfd00-be67-11e8-925c-a762c7950045.png)
+
+### With command line
+
+If you're not using VS Code, you can compile your project by running `haxe compile.hxml` from the command line. Then simply open the `index.html` file in your favorite browser.
 
 ## Debugging
 

--- a/Resource-Baking.md
+++ b/Resource-Baking.md
@@ -1,8 +1,8 @@
-In order to convert automatically some [Resources](Resource-Management) present in the `res` directory into a more appropriate runtime format, Heaps file system supports resource baking.
+In order to automatically convert some [Resources](Resource-Management) present in the `res` directory into a more appropriate runtime format, Heaps file system supports resource baking.
 
-This can be controlled by adding `props.json` configuration files in your `res` directory.
+This can be controlled by adding a `props.json` configuration file in your `res` directory.
 
-Here's for example a way to convert automatically all the `wav` sound files to `ogg` format:
+Here's for example a way to automatically convert all the `wav` sound files to `ogg` format:
 
 ```json
 {
@@ -12,16 +12,17 @@ Here's for example a way to convert automatically all the `wav` sound files to `
 }
 ```
 
-This will look for a `hxd.fs.Convert` registered instance that is capable of transforming `wav` to `ogg` and execute it when before wav file data is accessed. It will do the appropriate transformation and cache the result in `res/.tmp` directory. These tmp files should not be archived as they can easily be rebuilt.
+This will look for a `hxd.fs.Convert` registered instance that is capable of transforming `wav` to `ogg` and execute it before a wav file data is accessed. It will do the appropriate transformation and cache the result in `res/.tmp` directory. These tmp files should not be archived as they can easily be rebuilt.
 
-So when reading the `wav` content, you will instead get the `ogg` data. This is not a problem since heaps resources automatically detect the file type based on its data and not from its file extension.
+So when reading the `wav` content, you will instead get the `ogg` data. This is not a problem because heaps resources detect the file type based on its data and not from its file extension.
 
 Any resource file system will perform theses conversions:
-- LocalFileSystem at runtime, upon accessing the desired file
-- EmbedFileSytem at compile time, before embedding all files
-- PakFileSystem at PAK building time.
 
-Read [[Resource Management]] for an introduction on file systems.
+- `LocalFileSystem` at runtime, upon accessing the desired file
+- `EmbedFileSytem` at compile time, before embedding all files
+- `PakFileSystem` at PAK building time.
+
+Read [[Resource Management]] for an introduction to file systems.
 
 ## Default Configuration
 
@@ -57,7 +58,7 @@ For instance by adding this `props.json` file in `res/characters`, these rules w
 Each convert line is a _Rule_. Rules have the following possible syntax, by order of ascending default priority:
 
 - if `[a-z]+`: match a file with the given extension (case insensitive)
-- if starts with `^`: a regular expression that will be checked again both the file name and the full file path (will match if one of the two match
+- if starts with `^`: a regular expression that will be checked again both the file name and the full file path (will match if one of the two match)
 - if none of the above: a specific file name (will apply to all files within the directory and sub directories having this exact name)
 
 On the right side of each _Rule_, there's a convert _Command_. Commands have the following possible syntaxes:
@@ -66,11 +67,11 @@ On the right side of each _Rule_, there's a convert _Command_. Commands have the
 - `"xxx"` : any string identifying a convert. Usually a file extension to convert to.
 - `{ "convert" : "name", ...args }`: a convert with some specific arguments.
 - `{ "convert" : "name", "priority" : 5 }`: adjust manually the priority in terms of conflicting rules.
-- `{ "convert" : "name", "then" : <Command> }`: perform another convert command one this convert as run, enabling consecutive resources baking.
+- `{ "convert" : "name", "then" : <Command> }`: perform another convert command once this convert has run, enabling consecutive resources baking.
 
 ## Custom Converts
 
-Although Heaps already provide (some converts)[https://github.com/HeapsIO/heaps/blob/master/hxd/fs/Convert.hx] you can of course write your own in order to perform any resource transform your project needs.
+Although Heaps already provides [some converts](https://github.com/HeapsIO/heaps/blob/master/hxd/fs/Convert.hx), you can of course write your own in order to perform any resource transforms your project needs.
 
 Here's an example:
 
@@ -82,7 +83,7 @@ class MyCustomConvert extends hxd.fs.Convert {
     override function convert() {
         // make a simple copy
         var bytes = sys.io.File.getBytes(srcPath);
-        sys.io.File.saveBytes(dstPath, bytes); 
+        sys.io.File.saveBytes(dstPath, bytes);
     }
     // register the convert so it can be found
     static var _ = hxd.fs.Convert.register(new MyCustomConvert());
@@ -100,9 +101,10 @@ Then add the following to your `res/props.json` file:
 ```
 
 Depending on your file system, there are different ways to make sure the convert will be found:
-- if using the LocalFileSystem, simply compile it as part of your project
-- if using the PakFileSystem, compile it together with the Pak Builder script before running it
-- if using the EmbedFileSystem, you need to compile it with macros, for instance by adding `--macro MyCustomConvert.doNothing()` to your Haxe project command line parameters and adding a `public static function doNothing() {}` on `MyCustomConvert`
+
+- if using the `LocalFileSystem`, simply compile it as part of your project
+- if using the `PakFileSystem`, compile it together with the Pak Builder script before running it
+- if using the `EmbedFileSystem`, you need to compile it with macros, for instance by adding `--macro MyCustomConvert.doNothing()` to your Haxe project command line parameters and adding a `public static function doNothing() {}` on `MyCustomConvert`
 
 ## Multiple configurations
 
@@ -124,7 +126,7 @@ In order to setup multiple configurations, you can have different sections in yo
 ```
 
 In order to switch configuration, you can use the following:
-- for LocalFileSystem, use `hxd.Res.initLocal(configurationName)`
-- for EmbedFileSystem, use `hxd.Res.initEmbed(configurationName)`
-- for Pak File System, run pak builder with `-config <configurationName>`, this will output a `res.<config>.pak` file that you can load using `hxd.Res.initPak("res.<config>")`
 
+- for `LocalFileSystem`, use `hxd.Res.initLocal(configurationName)`
+- for `EmbedFileSystem`, use `hxd.Res.initEmbed(configurationName)`
+- for `PakFileSystem`, run pak builder with `-config <configurationName>`, this will output a `res.<config>.pak` file that you can load using `hxd.Res.initPak("res.<config>")`

--- a/Resource-Management.md
+++ b/Resource-Management.md
@@ -24,23 +24,23 @@ Please note that this is strictly typed: hxd.Res will look into the `res` direct
 
 ## Resources loader
 
-The `hxd.Res` provides your strictly typed shortcuts to access your resources, but it does not take care of the resource loading. For this, you need to initialize a resource loader before accessing your first resource, for instance:
+`hxd.Res` gives you strictly typed shortcuts to access your resources, but it does not take care of resource loading. For this, you need to initialize a resource loader before accessing your first resource, for instance:
 
 ```haxe
 hxd.Res.initEmbed();
 ```
 
-This will be the same as writing:
+This is the same as writing:
 
 ```haxe
 hxd.Res.loader = new hxd.res.Loader(hxd.fs.EmbedFileSystem.create());
 ```
 
-A loader will cache the resources instances after they have been fetched from the underlying file system. There are several ways to store your resources.
+A loader will cache the resource instances after they have been fetched from the underlying file system. There are several ways to store your resources.
 
 ### Dynamic resource resolution
 
-You can resolve a resource from it path in the resource file system by using the following command:
+You can resolve a resource from its path in the resource file system by using the following command:
 
 ```haxe
 hxd.Res.loader.load("path/to/myResource.png")
@@ -50,31 +50,31 @@ This will return a [hxd.res.Any](https://heaps.io/api/hxd/res/Any.html) which ha
 
 ### Resources with duplicate names and `Res` completion
 
-Because `Res` does not list the file extensions, there is a possibility for name conflicts between multiple resources, in this case both resources are listed with their extensions by using underscore instead of a dot.  
+Because `Res` does not list the file extensions, there is a possibility for name conflicts between multiple resources, in which case both resources are listed with their extension by using underscore instead of a dot.
 For example, `base.png` and `base.json` would be listed as a `base_png` and `base_json` resources in the completion.
 
-However some resource type have a so-called paired extensions, which can be found in the [hxd.res.Config](https://github.com/HeapsIO/heaps/blob/master/hxd/res/Config.hx) under `pairedExtensions` variable. When such file exists, if a file with same name exists and is listed as paired extension - it will be omitted from completion. Good example of that is `font.fnt` and `font.png`, which would only be listed as the `font` in `Res` and point at the `font.fnt`.
+However some resource types have so-called paired extensions, which can be found in the [hxd.res.Config](https://github.com/HeapsIO/heaps/blob/master/hxd/res/Config.hx) under `pairedExtensions` variable. When such a file exists, if a file with the same name exists and is listed as a paired extension - it will be omitted from completion. A good example of that is `font.fnt` and `font.png`, which would only be listed as the `font` in `Res` and point at `font.fnt`.
 
 ### Runtime resource loading
 
-You can also perform you own runtime loading of resources, by using for example `hxd.net.BinaryLoader`.
+You can also perform your own runtime loading of resources, by using for example `hxd.net.BinaryLoader`.
 Once you have the bytes for your resource, you can use `hxd.res.Any.fromBytes` to transform it into a proper resource.
 
 ## File Systems
 
-Resources files are accessed through a virtual file system which implements the [FileSystem](https://heaps.io/api/hxd/fs/FileSystem.html) interface. 
+Resource files are accessed through a virtual file system which implements the [FileSystem](https://heaps.io/api/hxd/fs/FileSystem.html) interface.
 
 Heaps already provides several file systems, such as:
 
- * [EmbedFileSystem](https://heaps.io/api/hxd/fs/EmbedFileSystem.html) will gives access to the resources which are embedded with your code (using haxe `-resource` compilation flag). On platforms such as JavaScript, this allows you to have both your code and assets stored in a single file.
- * [LocalFileSystem](https://heaps.io/api/hxd/fs/LocalFileSystem.html) which gives access to a local file system directory where your resources are stored. This require hard drive access so it is not available in the browser for example.
- * [hxd.fmt.pak.FileSystem](https://heaps.io/api/hxd/fmt/pak/FileSystem.html) will read a `.pak` file which contains all resources packaged into a single binary. The PAK file can be loaded at runtime and several PAK files can be used, the latest loaded being able to override the resources declared in previously loaded PAK files.  
+ * [EmbedFileSystem](https://heaps.io/api/hxd/fs/EmbedFileSystem.html) gives access to the resources which are embedded with your code (using haxe `-resource` compilation flag). On platforms such as JavaScript, this allows you to have both your code and assets stored in a single file.
+ * [LocalFileSystem](https://heaps.io/api/hxd/fs/LocalFileSystem.html) gives access to a local file system directory where your resources are stored. This requires hard drive access so it is not available in the browser for example.
+ * [hxd.fmt.pak.FileSystem](https://heaps.io/api/hxd/fmt/pak/FileSystem.html) reads a `.pak` file which contains all resources packaged into a single binary. The PAK file can be loaded at runtime and several PAK files can be used, the latest loaded being able to override the resources declared in previously loaded PAK files.
 
-You can initialize the resource loader and filesystem by yourself, or use one of the following shortcuts:
+You can initialize the resource loader and file system by yourself, or use one of the following shortcuts:
 
- * `hxd.Res.initEmbed()` for EmbedFileSystem - this will also trigger the embedding of all files present in your resource directory into your code
+ * `hxd.Res.initEmbed()` for EmbedFileSystem — this will also trigger the embedding of all files present in your resource directory into your code
  * `hxd.Res.initLocal()` for LocalFileSystem
- * `hxd.Res.initPak()` for PAK FileSystem - this will load res.pak, res1.pak, res2.pak, etc. from the local filesystem - until no file is found.
+ * `hxd.Res.initPak()` for PAK FileSystem — this will load res.pak, res1.pak, res2.pak, etc. from the local filesystem — until no file is found.
 
 ## Building PAK
 
@@ -101,10 +101,11 @@ This will be called before `init()`, and while loading `update()` and `onResize`
 
 ## Live update
 
-Heaps supports a live update system which can be enabled by compiling application with `-debug` flag or manually setting `hxd.res.Resource.LIVE_UPDATE` to `true`. Additionally, this is supported only when using `LocalFileSystem` (see above).  
+Heaps supports a live update system which can be enabled by compiling application with `-debug` flag or manually setting `hxd.res.Resource.LIVE_UPDATE` to `true`. Additionally, this is supported only when using `LocalFileSystem` (see above).
 Currently there are only two resource types that have built-in live update: `Image` and `Sound`.
 
 It is possible to attach custom callbacks for resource updates, which can be done via `hxd.res.Resource.watch` method, see sample code snippet:
+
 ```haxe
 function reloadParameters() {
   Game.monsterStats = Json.parse(hxd.Res.monster_stats.entry.getText());
@@ -117,13 +118,15 @@ hxd.Res.monster_stats.watch(reloadParameters);
 // When app no longer need to watch the resource, callback can be removed by passing `null` callback.
 hxd.Res.monster_stats.watch(null);
 ```
+
 Things to be aware of:
-* Only one callback can be present for a resource and new one will override old one.
-* When using `watch` to resouces with built-in support - it will break the built-in live update of said resource.
+
+* Only one callback can be present for a resource. Adding a new one will override the old one.
+* Using `watch` on resources with built-in support will break the built-in live update of that resource.
 
 ## Target-specific quirks
 
-Some targets do not support specific file formats and file-systems, but some can alleviated.
+Some targets do not support specific file formats and file systems, but in some cases that can alleviated.
 
-* On JS target, `ogg` is not supported. Can be enabled by using [stb_ogg_sound](https://lib.haxe.org/p/stb_ogg_sound/) library. Keep in mind that ogg decoder will not use browser capabilities.
-* On HL target, `mp3` is not added to `hxd.Res` listings because it is not recommended format due to its design (not very suitable for music loops), but it can be loaded manually as well as force-enabled in `Res` by adding `heaps_enable_hl_mp3` compilation flag.
+* On JS target, `ogg` is not supported. It can be enabled by using the [stb_ogg_sound](https://lib.haxe.org/p/stb_ogg_sound/) library. Keep in mind that ogg decoder will not use browser capabilities.
+* On HL target, `mp3` is not added to `hxd.Res` listings because it is not a recommended format due to its design (not very suitable for music loops), but it can be loaded manually as well as force-enabled in `Res` by adding the `heaps_enable_hl_mp3` compilation flag.

--- a/Sound.md
+++ b/Sound.md
@@ -1,17 +1,17 @@
 # Sound
 
-Heaps provides sound management. Heaps supports 3 different formats (WAV, MP3, OGG).  The availability of the formats depend on the platform (see [Resource manager](https://github.com/HeapsIO/heaps/wiki/Resource-Management#target-specific-quirks) page for details). You can determine which formats are supported using the following example:
+Heaps provides sound management. Heaps supports 3 different formats (WAV, MP3, OGG).  The availability of the formats depend on the platform (see [Resource manager](https://github.com/HeapsIO/heaps/wiki/Resource-Management#target-specific-quirks) for details). You can determine which formats are supported using the following example:
 
 ```haxe
 if(hxd.res.Sound.supportedFormat(Mp3)){
     //Mp3 is available
-} 
+}
 if(hxd.res.Sound.supportedFormat(OggVorbis)){
     //Ogg format is available
 }
 ```
 
-Sounds can be included in your project by specificying them at compile time in your HXML file
+Sounds can be included in your project by specificying them at compile time in your HXML file:
 
 ```hxml
 -D resourcesPath="../relative/path/to/sound/folder/"
@@ -26,7 +26,7 @@ var musicResource:Sound = null;
 //If we support mp3 we have our sound
 if(hxd.res.Sound.supportedFormat(Mp3)){
     musicResource = hxd.Res.my_music;
-}  
+}
 
 if(musicResource != null){
     //Play the music and loop it
@@ -36,9 +36,12 @@ if(musicResource != null){
 
 ## Channel, ChannelGroup and SoundGroup
 
-Each Channel instance belong to one SoundGroup and one ChannelGroup that allow to mass-control certain parameters of Channels.  
+Each `Channel` instance belongs to one `SoundGroup` and one `ChannelGroup` that allows to mass-control certain parameters of Channels.
+
 ### Channel
-Channel instance represents actively playing sound. It's possible to control following parameters on each Channel:
+
+Channel instance represents actively playing sound. It's possible to control the following parameters on each Channel:
+
 * `priority`: Priority of the Channel instance (when limiting maximum audible channels, lowest priority Channels get muted when limit is reached)
 * `mute`: Mutes channels. Note that playback still continues when channel is muted.
 * `volume`: Control volume of the Channel.
@@ -51,11 +54,15 @@ Channel instance represents actively playing sound. It's possible to control fol
 * `queue(s:Sound)`: Allows to queue next Sound to play with this Channel instance. It's possible to queue multiple sounds.
 
 ### SoundGroup
-Sound groups allow to control volume (multiplier), max audioble channels at once and force mono playback on Channel instances.
+
+Sound groups allow to control volume (multiplier), maximum number of audible channels at once and force mono playback on Channel instances.
+
 ### ChannelGroup
-Channel groups allow to control priority, mute, volume, fading and effects of multiple Channels that bellong to the group. Note that channel priority takes precedence over individual channel priorities.
+
+Channel groups allow to control priority, mute, volume, fading and effects of multiple Channels that belong to the group. Note that channel priority takes precedence over individual channel priorities.
 
 ## Manager
+
 Audio Manager instance provides API to general management of audio. It can be obtained with `hxd.snd.Manager.get()` call.
 Primary use is access to masterVolume, spatialization listener, as well as default sound and channel groups.
 
@@ -71,7 +78,7 @@ manager.stopByName("myGroupName");
 
 ## Effects
 
-When playing a sound, it's possible to attach effects to the Channel or ChannelGroup instance. Due to backend difference, some backends may not support all effect types. Following sample showcases usage of pitch effect:
+When playing a sound, it's possible to attach effects to the Channel or ChannelGroup instance. Due to backend differences, some backends may not support all effect types. The following sample showcases usage of the pitch effect:
 
 ```haxe
 var sound = Res.my_sound.play();
@@ -87,8 +94,10 @@ sound.removeEffect(pitch);
 ### Platform-specific limitations
 
 #### HTML5
-* Pitch: Due to how WebAudio works, changing pitch gradually can lead to audio cuts. This cannot be avoided due to pitch being applied only once in 128 samples and impossibility to obtain accurate current sample of audio buffer.
+
+* Pitch: Due to how WebAudio works, changing pitch gradually can lead to audio cuts. This cannot be avoided due to pitch being applied only once in 128 samples and the impossibility to obtain accurate current sample of audio buffer.
 * Spatialization: Velocity is not supported.
 
 #### OpenAL (Hashlink)
+
 * Spatialization: Only mono sounds are supported. (Use SoundGroup.mono to force mono playback)

--- a/Text.md
+++ b/Text.md
@@ -12,9 +12,9 @@ tf.textAlign = Center;
 
 // add to any parent, in this case we append to root
 s2d.addChild(tf);
-``` 
+```
 
-For each font family you need a different font file, but you can tint them with code, using `textColor`. 
+For each font family you need a different font file, but you can tint them with code, using `textColor`.
 
 ### HtmlText usage
 Along with regular Text, there is also an [h2d.HtmlText](https://heaps.io/api/h2d/HtmlText.html) class that allows to use simple html markdown for rich text.
@@ -31,7 +31,7 @@ Along with regular Text, there is also an [h2d.HtmlText](https://heaps.io/api/h2
 * `<i>`: Alias to `<font face="italic">`
 * `<br/>`: Creates a line-break.
 * `<img>`: Inserts an image.
-  * `src="myimage.png"`: Name of the image to load. See remarks about image loading beloew.
+  * `src="myimage.png"`: Name of the image to load. See remarks about image loading below.
 
 #### Font and image loading
 HtmlText does not use Resource Manager to load fonts or images. Loading is performed by setting the callback methods:
@@ -46,49 +46,49 @@ htmlText.loadImage = function( url : String ) : h2d.Tile { return null; }
 htmlText.loadFont = function( name : String ) : h2d.Font { return null; }
 htmlText.formatText = function ( text : String ) : String { return text; }
 ```
-It's up to user how to implement resource loading. Please note, that there is no tile/font caching on HtmlText side.  
+It's up to user how to implement resource loading. Please note, that there is no tile/font caching on HtmlText side.
 Lastly, `formatText` allows to modify and/or validate text contents when it's changed.
 
 ## Font creation
 
-If you want to use custom fonts, other than the Default one, you need to create a `.fnt` file and put it into your `res` directory.  
-Heaps automatically converts all supported `.fnt` files to its own `.bfnt` format to speed up font loading.  
+If you want to use custom fonts, other than the Default one, you need to create a `.fnt` file and put it into your `res` directory.
+Heaps automatically converts all supported `.fnt` files to its own `.bfnt` format to speed up font loading.
 Alternatively it is possible to use Signed Distance Field to generate scalable fonts. See Hiero section for details.
 
 ### Supported formats
 
-* All 3 BMFont formats: XML, Text and Binary.  
+* All 3 BMFont formats: XML, Text and Binary.
   _Note: Multiple images per font are not supported._
 * [FontBuilder](https://github.com/andryblack/fontbuilder): Divo (discouraged to use, as it is less advanced than BMFont)
 
 ### Convert font to bitmap font using BMfont tool
-  
+
 > Download BMFont here: <http://www.angelcode.com/products/bmfont/>
 
 In the BMFont-tool, use these settings:
 
 * _File_ → _Font settings_
  * Choose font
- * Choose size 
+ * Choose size
  * Render from TrueType outline _(if you want smooth fonts)_
 * _File_ → _Export settings_
   * Bit depth: 32
   * Preset: white text with alpha (black or outline w/ alpha will do as well, but black isn't tintable)
   * Font descriptor: Any
   * Texture: Png
-* _File_ → _Save bitmap font as.._ 
-  * Put in your Heaps project under `./res/fonts/myFontName.fnt` 
+* _File_ → _Save bitmap font as.._
+  * Put in your Heaps project under `./res/fonts/myFontName.fnt`
 * _Note:_ Multi-texture fnt files are not supported, ensure that there is only one font texture per fnt file.
 
 ### Convert font to bitmap font using Littera
 
-Due to browsers no longer supporting Flash, Littera can be ran only by older browser versions [here](http://www.kvazars.com/littera/) 
-or trough standalone flash player by running [swf file](http://www.kvazars.com/littera/littera.swf) directly.  
+Due to browsers no longer supporting Flash, Littera can be ran only by older browser versions [here](http://www.kvazars.com/littera/)
+or trough standalone flash player by running [swf file](http://www.kvazars.com/littera/littera.swf) directly.
 Use following settings:
 
 * Settings in the left column
   * Update a font from your computer with _Select Font_ button
-  * Choose size 
+  * Choose size
   * Set the values:
     * Select what glyphs do you want to export.
     * Fill: to get a non-gradient color, remove one of the markers dragging it down from the rectangle.
@@ -99,19 +99,19 @@ Use following settings:
   * Format: Either `XML (.fnt)` or `Text (.fnt)`
   * Default values are fine for Heaps
   * Press _Export_ start the downloading process.
-  * Unzip the file and put it's content in your Heaps project under `./res/fonts/` 
+  * Unzip the file and put it's content in your Heaps project under `./res/fonts/`
 * If you renamed the files, don't forget to update reference to font texture in `pages` section of `.fnt` file.
 
 ### Using libgdx Hiero
 
-[Hiero](https://libgdx.badlogicgames.com/tools.html) can be utilized to generate fonts with extra filters as well as SDF fonts. 
+[Hiero](https://libgdx.badlogicgames.com/tools.html) can be used to generate fonts with extra filters as well as SDF fonts.
 
 * Refer to this instruction to generate SDF fonts: [Distance Field Fonts](https://github.com/libgdx/libgdx/wiki/Distance-field-fonts)
 * Refer to this page for general instruction on Hiero usage: [Hiero](https://github.com/libgdx/libgdx/wiki/Hiero)
 
 ### Using fontgen tool
 
-[Fontgen](https://github.com/Yanrishatum/fontgen/) is a command-line utility to generate fonts including SDF and MSDF formats. It was written specifically for Heaps and ShiroGames.  
+[Fontgen](https://github.com/Yanrishatum/fontgen/) is a command-line utility to generate fonts including SDF and MSDF formats. It was written specifically for Heaps and ShiroGames.
 Utility is strictly command-line with config files, please refer to readme file.
 
 ### Be creative with bitmapfonts
@@ -123,6 +123,7 @@ Want gradients? Its not simple to add them with image-editing software if cells 
 ## Using the Font
 
 Once the font is ready, you can use it for your Text:
+
 * initialize the [Resource manager](https://github.com/HeapsIO/heaps/wiki/Resource-Management)
 * have a `.fnt` and the corresponding `.png` file in your `res` folder
   * For Divo, `.png` file should have exactly the same name as `.fnt`
@@ -131,11 +132,12 @@ Once the font is ready, you can use it for your Text:
 * create an `h2d.Text` using this font
 
 ### SDF / MSDF
+
 For SDF fonts you need to load fonts slightly differently.
 
 * Instead of `toFont()` use `toSdfFont(size, channel, alphaCutoff, smoothing)`
   * `size` will represent desired font size.
   * `channel` tells which texture channel SDF shader should take the information from.
   * `alphaCutoff` will set the border of a glyph, with `0.5` being default value.
-  * `smoothing` controls the amount of antialiasing applied to glyph borders. 
+  * `smoothing` controls the amount of antialiasing applied to glyph borders.
 * Set `Text.smoothing` to `true`, otherwise SDF won't render properly.


### PR DESCRIPTION
This fixes some spelling mistakes, some English mistakes, some incoherences (like wrong variable names), etc. This just makes the documentation, I hope, slightly more enjoyable to read.