### PR TITLE
Fixed typo (observerd -> observed)

### DIFF
--- a/H2D-Events-and-Interactivity.md
+++ b/H2D-Events-and-Interactivity.md
@@ -35,7 +35,7 @@ Don't forget to remove the event using removeEventTarget when disposing your obj
 
 ## Keyboard events
 
-Keyboard events can be observerd using the global event, check if the `event.kind` is `EKeyDown` or `EKeyUp`.
+Keyboard events can be observed using the global event, check if the `event.kind` is `EKeyDown` or `EKeyUp`.
 
 ```haxe
 function onEvent(event : hxd.Event) {


### PR DESCRIPTION
Fixes a small typo in the word "observed" that's misspelled as "observerd" under the Keyboard Events section.

Sources:
* https://heaps.io/documentation/h2d-events-and-interactivity.html