### PR TITLE
Fix broken domkit documentation

### DIFF
--- a/DomKit.md
+++ b/DomKit.md
@@ -59,7 +59,7 @@ flow.box {
 
 In order to get runtime CSS reload you need to:
 * use a `hxd.Res.initLocal()` so you use a local filesystem to load resources. This is only available on some platforms such as HashLink
-* enable resources live update with `hxd.Res.LIVE_UPDATE = true;`
+* enable live update of resources: `hxd.res.Resource.LIVE_UPDATE = true;` (enabled by default on `-D debug` builds)
 
 Then every time you modify your CSS file, the style will be reapplied to all your currently displayed components. Errors will be displayed in case of invalid CSS property or wrongly formatted value.
 

--- a/DomKit.md
+++ b/DomKit.md
@@ -49,7 +49,7 @@ style.addObject(view);
 Here's an example CSS that can be applied to previous view:
 
 ```css
-.box {
+flow.box {
     padding : 20;
     background : #400;
 }

--- a/DomKit.md
+++ b/DomKit.md
@@ -17,7 +17,7 @@ class SampleView extends h2d.Flow implements h2d.domkit.Object {
 
     static var SRC = 
         <sample-view layout="vertical"> 
-            Hello World! 
+            <text text={"Hello World!"}/>
             <bitmap src={tile} public id="mybmp"/>
         </sample-view>
 

--- a/DomKit.md
+++ b/DomKit.md
@@ -73,7 +73,7 @@ domkit.Macros.checkCSS("res/style.css");
 
 Or by adding to your Haxe compilation parameters:
 
-``` 
+```hxml
 --macro domkit.Macros.checkCSS('res/style.css')
 ```
 

--- a/DomKit.md
+++ b/DomKit.md
@@ -16,7 +16,7 @@ In order to use DomKit to create a Heaps components, you simply need to implemen
 class SampleView extends h2d.Flow implements h2d.domkit.Object {
 
     static var SRC = 
-        <sample-view layout="vertical"> 
+        <sample-view class="box" layout="vertical">
             <text text={"Hello World!"}/>
             <bitmap src={tile} public id="mybmp"/>
         </sample-view>

--- a/DomKit.md
+++ b/DomKit.md
@@ -249,11 +249,6 @@ ${ for( t in tiles ) <bitmap src={t} id="btns[]"/> }
 When using `${..}` syntax, you can inject any Haxe code into the markup language, allowing you to add if/for/method calls/etc.
 
 ```jsx
-Some Text
-```
-This is the equivalent of `<text text={"Some Text"}/>`, so you can apply CSS to the `text` components created this way.
-
-```jsx
 <node>$component</node>
 ```
 When just a Haxe variable identifier is injected into the document content, we assume it contains another component value to be inserted there.


### PR DESCRIPTION
Closes #84.

The css sample needs to have an actual component to avoid the "Unknown property padding" error.

It would be nice if the css sample could be:
```css
sample-view.box {
    padding : 20;
    background : #400;
}
```
But since the `sample-view` component is not in a registered path, there will be an error during the compile time css check. So it's simpler to just use flow so that the documentation doesn't become too complex:
```css
flow.box {
    padding : 20;
    background : #400;
}
```