### PR TITLE
Markdown link on this page not working -- fixing it

### DIFF
--- a/External-libraries.md
+++ b/External-libraries.md
@@ -12,4 +12,4 @@ These are ideas for open source dependencies you can use with Heaps (these are j
 - [raycast](https://lib.haxe.org/p/raycast/)
 - [gasm-heaps](https://lib.haxe.org/p/gasm-heaps/)
 
-Also check out [https://lib.haxe.org/search/?v=heaps](https://lib.haxe.org/search/?v=heaps) to find current links.
+Also search for Heaps libraries on [haxelib](https://lib.haxe.org/search/?v=heaps) to find current links.


### PR DESCRIPTION
https://heaps.io/documentation/external-libraries.html

Something in the markdown renderer isn't correctly rendering this link, probably because both the label and the link are valid http link URLs. It currently routes to "https://lib.haxe.org/search/?v=heaps](https://lib.haxe.org/search/?v=heaps)" instead of the intended "https://lib.haxe.org/search/?v=heaps".