### PR TITLE
Minor Grammatical Fix/Improvement

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -8,7 +8,7 @@ Heaps is currently working on:
 - Consoles (Nintendo Switch, Sony PS4, XBox One - requires being a registered developer)
 - Flash Stage3D
 
-The Heaps API is comprised of several top level packages, namely:
+The Heaps API comprises several top level packages, namely:
 
 - [`h2d`](https://github.com/ncannasse/heaps/wiki/H2D) used for 2D display (for 2D games and user interfaces)
 - [`h3d`](https://github.com/ncannasse/heaps/wiki/H3D) used for rendering 3D models


### PR DESCRIPTION
Hi!

### Grammatical Improvement
I have altered the documentation by altering the ungrammatical phrase 'comprised of'.

#### Description
All usages of 'comprised of' have been replaced with more suitable alternatives: 'comprises', 'composed of', 'including', ....

#### Justification
[Comprise or Compose? - Grammar Monster](https://www.grammar-monster.com/easily_confused/comprise_compose.htm)